### PR TITLE
Permit key with the same name as a protected property.

### DIFF
--- a/src/SelvinOrtiz/Zit/Zit.php
+++ b/src/SelvinOrtiz/Zit/Zit.php
@@ -111,15 +111,6 @@ class Zit implements IZit
 
 	public function __get($id)
 	{
-		$reflector = new ReflectionClass($this);
-		$properties = $reflector->getProperties(ReflectionProperty::IS_PUBLIC);
-
-		foreach ($properties as $property) {
-			if ($property->getName() === $id) {
-				return $this->{$id};
-			}
-		}
-
 		return $this->pop($id);
 	}
 

--- a/src/SelvinOrtiz/Zit/Zit.php
+++ b/src/SelvinOrtiz/Zit/Zit.php
@@ -1,9 +1,6 @@
 <?php
 namespace SelvinOrtiz\Zit;
 
-use ReflectionClass;
-use ReflectionProperty;
-
 /**
  * @=SelvinOrtiz\Zit
  *

--- a/src/SelvinOrtiz/Zit/Zit.php
+++ b/src/SelvinOrtiz/Zit/Zit.php
@@ -1,6 +1,9 @@
 <?php
 namespace SelvinOrtiz\Zit;
 
+use ReflectionClass;
+use ReflectionProperty;
+
 /**
  * @=SelvinOrtiz\Zit
  *
@@ -20,7 +23,7 @@ class Zit implements IZit
 	protected $services		= array();
 	protected $callables	= array();
 
-	protected function __construct() 	{}
+	protected function __construct()	{}
 	protected function __clone()		{}
 
 	/**
@@ -108,14 +111,16 @@ class Zit implements IZit
 
 	public function __get($id)
 	{
-		if (property_exists($this, $id))
-		{
-			return $this->{$id};
+		$reflector = new ReflectionClass($this);
+		$properties = $reflector->getProperties(ReflectionProperty::IS_PUBLIC);
+
+		foreach ($properties as $property) {
+			if ($property->getName() === $id) {
+				return $this->{$id};
+			}
 		}
-		else
-		{
-			return $this->pop($id);
-		}
+
+		return $this->pop($id);
 	}
 
 	public function __call($id, $args=array())

--- a/tests/ZitTest.php
+++ b/tests/ZitTest.php
@@ -52,4 +52,17 @@ class ZitTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue( $zit->myCallable() === 12345 );
 		$this->assertTrue( Zit::myCallable() === 12345 );
 	}
+
+	public function testStashWithSameIdAsProtectedProperty()
+	{
+		$zit = Zit::getInstance();
+
+		$instance = new \stdClass;
+		$instance->id = 'testServices';
+
+		$zit->stash('services', $instance);
+
+		$this->assertTrue($zit->services instanceof \stdClass);
+		$this->assertSame('testServices', $zit->services->id);
+	}
 }


### PR DESCRIPTION
Hi Selvin,

At present it's not possible to "stash" or "bind" something using the same key as a protected property. The `__get` magic method checks whether the property exists, but makes no distinction between public and protected properties (I ran into this whilst trying to stash some `services`).

This pull request ensures that we only check for public properties, before resorting to the `pop` method.

Stephen
